### PR TITLE
Add possibility to indent GPX output

### DIFF
--- a/src/main/java/me/himanshusoni/gpxparser/GPXWriter.java
+++ b/src/main/java/me/himanshusoni/gpxparser/GPXWriter.java
@@ -10,6 +10,7 @@ import org.w3c.dom.Node;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
@@ -21,6 +22,10 @@ import java.util.Map;
 public class GPXWriter extends BaseGPX {
 
     public void writeGPX(GPX gpx, OutputStream out) throws ParserConfigurationException, TransformerException {
+        writeGPX(gpx, out, 0);
+    }
+
+    public void writeGPX(GPX gpx, OutputStream out, int intent) throws ParserConfigurationException, TransformerException {
         // TFE, 20180217: add default parser if none set
         if (this.extensionParsers.isEmpty()) {
             this.extensionParsers.add(new DummyExtensionParser());
@@ -77,6 +82,10 @@ public class GPXWriter extends BaseGPX {
 
         DOMSource source = new DOMSource(doc);
         StreamResult result = new StreamResult(out);
+        if (intent > 0) {
+            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+            transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", Integer.toString(intent));
+        }
         transformer.transform(source, result);
     }
 

--- a/src/main/java/me/himanshusoni/gpxparser/GPXWriter.java
+++ b/src/main/java/me/himanshusoni/gpxparser/GPXWriter.java
@@ -25,7 +25,7 @@ public class GPXWriter extends BaseGPX {
         writeGPX(gpx, out, 0);
     }
 
-    public void writeGPX(GPX gpx, OutputStream out, int intent) throws ParserConfigurationException, TransformerException {
+    public void writeGPX(GPX gpx, OutputStream out, int indent) throws ParserConfigurationException, TransformerException {
         // TFE, 20180217: add default parser if none set
         if (this.extensionParsers.isEmpty()) {
             this.extensionParsers.add(new DummyExtensionParser());
@@ -82,9 +82,9 @@ public class GPXWriter extends BaseGPX {
 
         DOMSource source = new DOMSource(doc);
         StreamResult result = new StreamResult(out);
-        if (intent > 0) {
+        if (indent > 0) {
             transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-            transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", Integer.toString(intent));
+            transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", Integer.toString(indent));
         }
         transformer.transform(source, result);
     }


### PR DESCRIPTION
This implements #28. I added an override for the existing method so compatibility with existing code doesn't break.